### PR TITLE
Add Copy Vanilla CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules
+package-lock.json
 /dist
 
 # local env files

--- a/src/components/ClickCopy.vue
+++ b/src/components/ClickCopy.vue
@@ -26,13 +26,25 @@ export default {
     gradient: String,
     name: String,
     vanilla: Boolean,
-    value: String,
+  },
+  data() {
+    return {
+      mounted: false,
+    }
   },
   mounted() {
-    this.value = this.vanilla ? getComputedStyle(this.$refs.gradientUnderline).getPropertyValue('background-image') : this.gradient
+    this.mounted = true
   },
-  updated() {
-    this.value = this.vanilla ? getComputedStyle(this.$refs.gradientUnderline).getPropertyValue('background-image') : this.gradient
+  computed: {
+    value() {
+      if (!this.mounted) return null
+      
+      if (this.vanilla) {
+        return getComputedStyle(this.$refs.gradientUnderline).getPropertyValue('background-image')
+      }
+
+      return this.gradient
+    }
   },
   methods: {
     onCopy(e) {

--- a/src/components/ClickCopy.vue
+++ b/src/components/ClickCopy.vue
@@ -5,16 +5,16 @@
       <button
         class="text-sm font-medium focus:outline-none focus:shadow-outline text-app-text"
         type="button"
-        v-clipboard:copy="gradient"
+        v-clipboard:copy="value"
         v-clipboard:success="onCopy"
         v-clipboard:error="onError"
         :data-gradient="name"
       >
-        Copy CSS
+        Copy <span v-if="vanilla">Vanilla</span> CSS
       </button>
       <span
         class="inline-block w-6 h-1 mt-1 duration-100 ease-in-out rounded-full transition-size group-hover:w-full"
-        :class="gradient"
+        :class="gradient" ref="gradientUnderline"
       ></span>
     </div>
   </div>
@@ -25,6 +25,14 @@ export default {
   props: {
     gradient: String,
     name: String,
+    vanilla: Boolean,
+    value: String,
+  },
+  mounted() {
+    this.value = this.vanilla ? getComputedStyle(this.$refs.gradientUnderline).getPropertyValue('background-image') : this.gradient
+  },
+  updated() {
+    this.value = this.vanilla ? getComputedStyle(this.$refs.gradientUnderline).getPropertyValue('background-image') : this.gradient
   },
   methods: {
     onCopy(e) {

--- a/src/components/Gradient.vue
+++ b/src/components/Gradient.vue
@@ -8,6 +8,7 @@
           {{ customisedColors }}
         </div>
         <ClickCopy :gradient="customisedColors" :name="title" />
+        <ClickCopy :gradient="customisedColors" :name="title" :vanilla="true" />
       </div>
       <div class="space-y-4">
         <h2 class="font-bold text-app-text">Direction</h2>


### PR DESCRIPTION
### Context
Closes #4 

### Changes proposed in this pull request
- _Add `package-lock.json` to `.gitignore` because this project uses Yarn_
- Add a button to copy the vanilla `linear-gradient()`
  - Add a `vanilla` prop to keep one `ClickCopy` component
  - Add a `value` prop which holds the value to be copied, which can either be Tailwind classes or a `linear-gradient()`

### Guidance to review

I have two concerns:
- Maybe change the buttons' labels to be more specific about what they are copying (e.g. "Copy Tailwind classes" and "Copy Vanilla gradient")
- Basically, **`getComputedStyle()` needs a reference to a DOM element**. Therefore I tried using `ref`, but it's populated after the first render, so the initial load of `ClickCopy` can't access the DOM element. My workaround was to use a prop that I mutate in `mounted()` and `updated()`, but it's bad practice.

I just discovered Vue.js and tried to do my best, but because of the latter point there are warnings in the console.

I'm waiting to see what you will suggest to me 😀