### PR TITLE
fix(a11y): select background color

### DIFF
--- a/components/generator/Select.vue
+++ b/components/generator/Select.vue
@@ -8,11 +8,11 @@
 
     <select
       :id="id"
-      class="w-full p-3 font-medium rounded-xl bg-gray-800/10 border-gray-800/75 sm:text-sm"
+      class="w-full p-3 font-medium rounded-xl bg-gray-900 border-gray-800/75 sm:text-sm"
       :value="value"
       @input="$emit('input', $event.target.value)"
     >
-      <option  class="bg-gray-800" v-for="item of items" :key="item" :value="item" v-text="item" />
+      <option v-for="item of items" :key="item" :value="item" v-text="item" />
     </select>
   </div>
 </template>

--- a/components/generator/Select.vue
+++ b/components/generator/Select.vue
@@ -12,7 +12,7 @@
       :value="value"
       @input="$emit('input', $event.target.value)"
     >
-      <option v-for="item of items" :key="item" :value="item" v-text="item" />
+      <option  class="bg-gray-800" v-for="item of items" :key="item" :value="item" v-text="item" />
     </select>
   </div>
 </template>


### PR DESCRIPTION
I Just found that the background color of generator options was almost the same as the text color so I changed it to `bg-gray-800`
 
####before 
![,](https://res.cloudinary.com/dkllkhj3z/image/upload/v1645545437/s_atkbjs.jpg)

####after
![,](https://res.cloudinary.com/dkllkhj3z/image/upload/v1645545438/after_wcj7zw.jpg)