### PR TITLE
fix/gradients/flags

### DIFF
--- a/assets/data/flags.js
+++ b/assets/data/flags.js
@@ -142,7 +142,7 @@ export const gradients = [
       'bg-[linear-gradient(90deg,_#002B7F_33.333%,_#FCD116_33.333%_66.666%,_#CE1126_66.666%)]'
   },
   {
-    name: 'Sierra Leon',
+    name: 'Sierra Leone',
     colors:
       'bg-[linear-gradient(180deg,_#1EB53A_33.333%,_#FFF_33.333%_66.666%,_#0072C6_66.666%)]'
   },

--- a/assets/data/flags.js
+++ b/assets/data/flags.js
@@ -120,7 +120,7 @@ export const gradients = [
   {
     name: 'Netherlands',
     colors:
-      'bg-[linear-gradient(90deg,_#AE1C28_33.333%,_#FFF_33.333%_66.666%,_#21468B_66.666%)]'
+      'bg-[linear-gradient(180deg,_#AE1C28_33.333%,_#FFF_33.333%_66.666%,_#21468B_66.666%)]'
   },
   {
     name: 'Nigeria',

--- a/assets/data/flags.js
+++ b/assets/data/flags.js
@@ -134,7 +134,7 @@ export const gradients = [
   },
   {
     name: 'Poland',
-    colors: 'bg-[linear-gradient(180deg,_#D22630_50%,_#FFF_50%)]'
+    colors: 'bg-[linear-gradient(0deg,_#D22630_50%,_#FFF_50%)]'
   },
   {
     name: 'Romania',


### PR DESCRIPTION
This pull request fixes a few mistakes with gradient flags.

- Rotates the flag of the Netherlands by 90 degrees clockwise.
- Rotates the flag of Poland by 180 degrees.
- Updates the name of Sierra Leone country (previously: `Sierra Leon`).