### PR TITLE
Fix - Force screen to be full height

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,7 @@
   <div class="bg-gray-900">
     <global-header />
 
-    <main>
+    <main style="min-height: calc(100vh - 198px)">
       <Nuxt />
     </main>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="bg-gray-900">
+  <div class="flex flex-col justify-between min-h-screen bg-gray-900">
     <global-header />
 
-    <main style="min-height: calc(100vh - 198px)">
+    <main>
       <Nuxt />
     </main>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
   content: [
     'assets/**/*.js',
     'components/**/*.{vue,js}',
+    'layouts/**/*.{vue,js}',
     'pages/**/*.{vue,js}'
   ],
   safelist: [


### PR DESCRIPTION
Great website! However I noticed on large screens the content does not fill the entire browser window. This is especially evident when there is little content on a page. This PR addresses that issue by filling remaining space. 

I noticed this on both the favorite and generator page

## Favorite page

**Before:**
![image](https://user-images.githubusercontent.com/32209255/210958001-28d8aa48-614b-4932-afe8-17c4e9f51e3c.png)

**After:**
![image](https://user-images.githubusercontent.com/32209255/210958170-7514cc80-6c3e-45e2-9539-457b8c9c5276.png)

## Generator page
**Before:**
![image](https://user-images.githubusercontent.com/32209255/210958239-7be33ed5-c9d7-4503-b4a5-ab3ebd22f3c3.png)

**After:**
![image](https://user-images.githubusercontent.com/32209255/210958355-d1f21922-8e41-424f-9413-2657e0e1bce7.png)

Keep up the great work 🚀  