### PR TITLE
Hotfix - Correct display name

### DIFF
--- a/assets/data/directionOptions.js
+++ b/assets/data/directionOptions.js
@@ -12,7 +12,7 @@ export const primaryDirections = [
     css: 'bg-gradient-to-r'
   },
   {
-    name: 'To Bottom Top',
+    name: 'To Bottom Right',
     css: 'bg-gradient-to-br'
   },
   {


### PR DESCRIPTION
Currently the display name for `bg-gradient-to-br` is incorrectly shown as `To Bottom Top`

<img width="277" alt="Screenshot 2023-02-05 at 8 58 30 PM" src="https://user-images.githubusercontent.com/53750093/216828520-3e57b5a3-3b0c-48a0-8508-30637a2b7146.png">

This PR fixes that to display `To Bottom Right`
